### PR TITLE
Refactored JS and CSS includes to use wp_enqueue methods

### DIFF
--- a/wp_code_highlight.js.php
+++ b/wp_code_highlight.js.php
@@ -154,17 +154,15 @@ function hljs_include() {
     if (!empty($hljs_cdn_list[$hljs_location]))
         $hljs_cdn_info = $hljs_cdn_list[$hljs_location];
 
-    // inject jquery
-    wp_enqueue_script('jquery');
-
-    // inject js & css file
-    if ('local' == $hljs_cdn_info['cdn']) { ?>
-    <script type="text/javascript" src="<?php echo ($PLUGIN_DIR . '/highlight.' . $hljs_package .'.pack.js'); ?>"></script>
-    <link rel="stylesheet" href="<?php echo ($PLUGIN_DIR . '/styles/' . $hljs_code_option['theme'] . '.css'); ?>" />
-<?php } else { ?>
-    <script type="text/javascript" src="<?php echo ($hljs_cdn_info['cdn'] . '/highlight' . $hljs_cdn_info['js'] . '.js'); ?>"></script>
-    <link rel="stylesheet" href="<?php echo ($hljs_cdn_info['cdn'] . '/styles/' . $hljs_code_option['theme'] . $hljs_cdn_info['css'] . '.css'); ?>" />
-<?php } 
+    // inject js & css file    
+    if ( 'local' == $hljs_cdn_info['cdn'] ) {
+        wp_enqueue_script( 'hljs', $PLUGIN_DIR . '/highlight.' . $hljs_package .'.pack.js', 'jquery' );
+        wp_enqueue_style( 'hljstheme', $PLUGIN_DIR . '/styles/' . $hljs_code_option['theme'] . '.css' );
+    } else {
+        wp_enqueue_script( 'hljs', $hljs_cdn_info['cdn'] . '/highlight' . $hljs_cdn_info['js'] . '.js', 'jquery' );
+        wp_enqueue_style( 'hljstheme', $hljs_cdn_info['cdn'] . '/styles/' . $hljs_code_option['theme'] . $hljs_cdn_info['css'] . '.css' );
+    }
+    
 
     // inject init script
     $hljs_lib_configure = false;


### PR DESCRIPTION
Improvement: By including them using the enqueue methods other plugins can interact with theme as required to enable their functionality.

e.g.  minify plugin can now un-enqueue them and combine them/minify them with other script and style and do whatever they need/want to do..
