### PR TITLE
support <PRE class="prettyprint"> legacy structure

### DIFF
--- a/wp_code_highlight.js.php
+++ b/wp_code_highlight.js.php
@@ -281,9 +281,15 @@ function hljs_append_init_codes() {
                 return;
             }
 
-            var code_content = jblock.html();
-            jblock.replaceWith($("<pre></pre>").append($("<code class='hljs'></code>").html(code_content)));
-            hljs.highlightBlock(jblock.get(0));
+            if (jblock.prop("tagName") === "PRE") {
+              jblock.wrapInner("<code class='hljs'></code>");
+              hljs.highlightBlock(jblock.children().get(0));
+            }
+            else {
+              var code_content = jblock.html();
+              jblock.replaceWith($("<pre></pre>").append($("<code class='hljs'></code>").html(code_content)));
+              hljs.highlightBlock(jblock.get(0));
+            }
         });
 <?php } 
     //crayon compatible


### PR DESCRIPTION
small tweak to the prettyify_compatible logic to support single <PRE class="prettyprint"> structure... existing code seems to be bug due to replacewith not leaving jblock pointing at the new DOM element but i left it in else {} clause in case it applies to another scenario
