### PR TITLE
Updates the code shortcode to work with xml/html

### DIFF
--- a/wp_code_highlight.js.php
+++ b/wp_code_highlight.js.php
@@ -368,6 +368,9 @@ function hljs_code_handler($attrs, $content) {
             $enable_inner_bbcode = false;
         }
     }
+    if($attrs['lang'] == "xml"){
+        $content = htmlentities(str_replace(array("<p>", "<br>", "</p>"), "",  $content));
+    }
     if($enable_inner_bbcode) {
         return "<pre class=\"hljs\"><code $language>" . do_shortcode(ltrim($content, '\n')) . '</code></pre>';
     } else {


### PR DESCRIPTION
Hey buddy I was unable to use xml/html in shortcode it would break the page and render the HTML instead of showing the code. I basically check to see if its lang = XML and then I filter the HTML entities and replace the auto added WordPress tags. We can discuss or modify the functionality.