### PR TITLE
Fix the wrong trimming in [code] shortcodes

### DIFF
--- a/wp_code_highlight.js.php
+++ b/wp_code_highlight.js.php
@@ -369,9 +369,9 @@ function hljs_code_handler($attrs, $content) {
         }
     }
     if($enable_inner_bbcode) {
-        return "<pre><code $language>" . do_shortcode(ltrim($content, '\n')) . '</code></pre>';
+        return "<pre><code $language>" . do_shortcode(ltrim($content, "\n")) . '</code></pre>';
     } else {
-        return "<pre><code $language>" . ltrim($content, '\n') . '</code></pre>';
+        return "<pre><code $language>" . ltrim($content, "\n") . '</code></pre>';
     }
 }
 if (hljs_get_option('shortcode')) {


### PR DESCRIPTION
Strings in single quotes don’t support any escape sequences except `\'` and `\\`. Because of this, ltrim(..., `\n`) is interpreted as trimming `\` and `n` charachers. This PR fixes this.

Here’s the working example with wrong trimming: https://3v4l.org/j07Rd